### PR TITLE
Add pagination to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You will need the following things properly installed on your computer.
 ## Installation
 
 With [Go module](https://github.com/golang/go/wiki/Modules) support (Go 1.11+),
-simply add the following import
+add the following import
 
 ```go
 import "github.com/StatusCakeDev/statuscake-go"
@@ -27,6 +27,33 @@ Otherwise, to install the `statuscake-go` package, run the following command:
 
 ```bash
 $ go get -u github.com/StatusCakeDev/statuscake-go
+```
+
+## Usage
+
+Within any Go file instantiate an API client and execute a request:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/StatusCakeDev/statuscake-go"
+	"github.com/StatusCakeDev/statuscake-go/credentials"
+)
+
+func main() {
+	bearer := credentials.NewBearerWithStaticToken(apiToken)
+	client := statuscake.NewClient(statuscake.WithRequestCredentials(bearer))
+
+	tests, err := client.ListUptimeTests(context.Background()).Execute()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printg("%+v\n", tests.Data)
 ```
 
 ## License

--- a/api_contact_groups.go
+++ b/api_contact_groups.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -531,6 +531,20 @@ func (a *ContactGroupsService) GetContactGroupExecute(r APIGetContactGroupReques
 type APIListContactGroupsRequest struct {
 	ctx        context.Context
 	APIService ContactGroupsAPI
+	page       *int32
+	limit      *int32
+}
+
+// Page sets page on the request type.
+func (r APIListContactGroupsRequest) Page(page int32) APIListContactGroupsRequest {
+	r.page = &page
+	return r
+}
+
+// Limit sets limit on the request type.
+func (r APIListContactGroupsRequest) Limit(limit int32) APIListContactGroupsRequest {
+	r.limit = &limit
+	return r
 }
 
 // Execute executes the request.
@@ -575,6 +589,12 @@ func (a *ContactGroupsService) ListContactGroupsExecute(r APIListContactGroupsRe
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
+	if r.page != nil {
+		queryParams.Add("page", parameterToString(*r.page))
+	}
+	if r.limit != nil {
+		queryParams.Add("limit", parameterToString(*r.limit))
+	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
 

--- a/api_contact_groups_test.go
+++ b/api_contact_groups_test.go
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -280,6 +280,12 @@ func TestListContactGroups(t *testing.T) {
 						"ping_url":        Like("https://ping.example.com"),
 					}, 1,
 				),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": Like(5),
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
@@ -316,6 +322,12 @@ func TestListContactGroups(t *testing.T) {
 			WithHeader("Content-Type", S("application/json")).
 			WithJSONBody(Map{
 				"data": Like([]interface{}{}),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": 0,
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {

--- a/api_locations.go
+++ b/api_locations.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/api_locations_test.go
+++ b/api_locations_test.go
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/api_maintenance_windows_.go
+++ b/api_maintenance_windows_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -543,7 +543,21 @@ func (a *MaintenanceWindowsService) GetMaintenanceWindowExecute(r APIGetMaintena
 type APIListMaintenanceWindowsRequest struct {
 	ctx        context.Context
 	APIService MaintenanceWindowsAPI
+	page       *int32
+	limit      *int32
 	state      *string
+}
+
+// Page sets page on the request type.
+func (r APIListMaintenanceWindowsRequest) Page(page int32) APIListMaintenanceWindowsRequest {
+	r.page = &page
+	return r
+}
+
+// Limit sets limit on the request type.
+func (r APIListMaintenanceWindowsRequest) Limit(limit int32) APIListMaintenanceWindowsRequest {
+	r.limit = &limit
+	return r
 }
 
 // State sets state on the request type.
@@ -594,6 +608,12 @@ func (a *MaintenanceWindowsService) ListMaintenanceWindowsExecute(r APIListMaint
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
+	if r.page != nil {
+		queryParams.Add("page", parameterToString(*r.page))
+	}
+	if r.limit != nil {
+		queryParams.Add("limit", parameterToString(*r.limit))
+	}
 	if r.state != nil {
 		queryParams.Add("state", parameterToString(*r.state))
 	}

--- a/api_maintenance_windows__test.go
+++ b/api_maintenance_windows__test.go
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -288,6 +288,12 @@ func TestListMaintenanceWindows(t *testing.T) {
 						"timezone":        "UTC",
 					}, 1,
 				),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": Like(5),
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
@@ -325,6 +331,12 @@ func TestListMaintenanceWindows(t *testing.T) {
 			WithHeader("Content-Type", S("application/json")).
 			WithJSONBody(Map{
 				"data": Like([]interface{}{}),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": 0,
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {

--- a/api_pagespeed.go
+++ b/api_pagespeed.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -553,12 +553,19 @@ type APIListPagespeedTestHistoryRequest struct {
 	ctx        context.Context
 	APIService PagespeedAPI
 	testId     string
-	days       *int32
+	limit      *int32
+	before     *int64
 }
 
-// Days sets days on the request type.
-func (r APIListPagespeedTestHistoryRequest) Days(days int32) APIListPagespeedTestHistoryRequest {
-	r.days = &days
+// Limit sets limit on the request type.
+func (r APIListPagespeedTestHistoryRequest) Limit(limit int32) APIListPagespeedTestHistoryRequest {
+	r.limit = &limit
+	return r
+}
+
+// Before sets before on the request type.
+func (r APIListPagespeedTestHistoryRequest) Before(before int64) APIListPagespeedTestHistoryRequest {
+	r.before = &before
 	return r
 }
 
@@ -606,8 +613,11 @@ func (a *PagespeedService) ListPagespeedTestHistoryExecute(r APIListPagespeedTes
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
-	if r.days != nil {
-		queryParams.Add("days", parameterToString(*r.days))
+	if r.limit != nil {
+		queryParams.Add("limit", parameterToString(*r.limit))
+	}
+	if r.before != nil {
+		queryParams.Add("before", parameterToString(*r.before))
 	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
@@ -674,6 +684,20 @@ func (a *PagespeedService) ListPagespeedTestHistoryExecute(r APIListPagespeedTes
 type APIListPagespeedTestsRequest struct {
 	ctx        context.Context
 	APIService PagespeedAPI
+	page       *int32
+	limit      *int32
+}
+
+// Page sets page on the request type.
+func (r APIListPagespeedTestsRequest) Page(page int32) APIListPagespeedTestsRequest {
+	r.page = &page
+	return r
+}
+
+// Limit sets limit on the request type.
+func (r APIListPagespeedTestsRequest) Limit(limit int32) APIListPagespeedTestsRequest {
+	r.limit = &limit
+	return r
 }
 
 // Execute executes the request.
@@ -718,6 +742,12 @@ func (a *PagespeedService) ListPagespeedTestsExecute(r APIListPagespeedTestsRequ
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
+	if r.page != nil {
+		queryParams.Add("page", parameterToString(*r.page))
+	}
+	if r.limit != nil {
+		queryParams.Add("limit", parameterToString(*r.limit))
+	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
 

--- a/api_pagespeed_test.go
+++ b/api_pagespeed_test.go
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -310,6 +310,12 @@ func TestListPagespeedTests(t *testing.T) {
 						"paused":   Like(true),
 					}, 1,
 				),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": Like(5),
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
@@ -351,6 +357,12 @@ func TestListPagespeedTests(t *testing.T) {
 			WithHeader("Content-Type", S("application/json")).
 			WithJSONBody(Map{
 				"data": Like([]interface{}{}),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": 0,
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
@@ -369,7 +381,6 @@ func TestListPagespeedTestHistory(t *testing.T) {
 			}).
 			UponReceiving("A request to get a list of pagespeed test history results").
 			WithRequest(http.MethodGet, FromProviderState("/v1/pagespeed/${id}/history", "/v1/pagespeed/1/history")).
-			WithQuery("days", Integer(10)).
 			WithHeaders(matchers.HeadersMatcher{
 				"Accept":        []Matcher{S("application/json")},
 				"Authorization": []Matcher{S("Bearer 123456789")},
@@ -410,9 +421,7 @@ func TestListPagespeedTestHistory(t *testing.T) {
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
-			results, _ := c.ListPagespeedTestHistory(context.Background(), "1").
-				Days(10).
-				Execute()
+			results, _ := c.ListPagespeedTestHistory(context.Background(), "1").Execute()
 
 			return equal(results.Data, statuscake.PagespeedTestHistoryData{
 				Aggregated: statuscake.PagespeedTestHistoryDataAggregated{
@@ -452,7 +461,6 @@ func TestListPagespeedTestHistory(t *testing.T) {
 			AddInteraction().
 			UponReceiving("A request to get a list of pagespeed test history results").
 			WithRequest(http.MethodGet, S("/v1/pagespeed/2/history")).
-			WithQuery("days", Integer(10)).
 			WithHeaders(matchers.HeadersMatcher{
 				"Accept":        []Matcher{S("application/json")},
 				"Authorization": []Matcher{S("Bearer 123456789")},
@@ -465,9 +473,7 @@ func TestListPagespeedTestHistory(t *testing.T) {
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
-			_, err := c.ListPagespeedTestHistory(context.Background(), "2").
-				Days(10).
-				Execute()
+			_, err := c.ListPagespeedTestHistory(context.Background(), "2").Execute()
 
 			return equal(err, statuscake.APIError{
 				Status:  http.StatusNotFound,
@@ -485,7 +491,6 @@ func TestListPagespeedTestHistory(t *testing.T) {
 			}).
 			UponReceiving("A request to get a list of pagespeed test history results").
 			WithRequest(http.MethodGet, FromProviderState("/v1/pagespeed/${id}/history", "/v1/pagespeed/1/history")).
-			WithQuery("days", Integer(10)).
 			WithHeaders(matchers.HeadersMatcher{
 				"Accept":        []Matcher{S("application/json")},
 				"Authorization": []Matcher{S("Bearer 123456789")},
@@ -497,9 +502,7 @@ func TestListPagespeedTestHistory(t *testing.T) {
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
-			results, _ := c.ListPagespeedTestHistory(context.Background(), "1").
-				Days(10).
-				Execute()
+			results, _ := c.ListPagespeedTestHistory(context.Background(), "1").Execute()
 
 			return equal(results.Data, statuscake.PagespeedTestHistoryData{})
 		})

--- a/api_ssl.go
+++ b/api_ssl.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -615,6 +615,20 @@ func (a *SslService) GetSslTestExecute(r APIGetSslTestRequest) (SSLTestResponse,
 type APIListSslTestsRequest struct {
 	ctx        context.Context
 	APIService SslAPI
+	page       *int32
+	limit      *int32
+}
+
+// Page sets page on the request type.
+func (r APIListSslTestsRequest) Page(page int32) APIListSslTestsRequest {
+	r.page = &page
+	return r
+}
+
+// Limit sets limit on the request type.
+func (r APIListSslTestsRequest) Limit(limit int32) APIListSslTestsRequest {
+	r.limit = &limit
+	return r
 }
 
 // Execute executes the request.
@@ -659,6 +673,12 @@ func (a *SslService) ListSslTestsExecute(r APIListSslTestsRequest) (SSLTests, er
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
+	if r.page != nil {
+		queryParams.Add("page", parameterToString(*r.page))
+	}
+	if r.limit != nil {
+		queryParams.Add("limit", parameterToString(*r.limit))
+	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
 

--- a/api_ssl_test.go
+++ b/api_ssl_test.go
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -388,6 +388,12 @@ func TestListSSLTests(t *testing.T) {
 						"valid_until": Timestamp(),
 					}, 1,
 				),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": Like(5),
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
@@ -445,6 +451,12 @@ func TestListSSLTests(t *testing.T) {
 			WithHeader("Content-Type", S("application/json")).
 			WithJSONBody(Map{
 				"data": Like([]interface{}{}),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": 0,
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {

--- a/api_uptime.go
+++ b/api_uptime.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -908,19 +908,19 @@ type APIListUptimeTestAlertsRequest struct {
 	ctx        context.Context
 	APIService UptimeAPI
 	testId     string
-	start      *int64
 	limit      *int32
-}
-
-// Start sets start on the request type.
-func (r APIListUptimeTestAlertsRequest) Start(start int64) APIListUptimeTestAlertsRequest {
-	r.start = &start
-	return r
+	before     *int64
 }
 
 // Limit sets limit on the request type.
 func (r APIListUptimeTestAlertsRequest) Limit(limit int32) APIListUptimeTestAlertsRequest {
 	r.limit = &limit
+	return r
+}
+
+// Before sets before on the request type.
+func (r APIListUptimeTestAlertsRequest) Before(before int64) APIListUptimeTestAlertsRequest {
+	r.before = &before
 	return r
 }
 
@@ -968,11 +968,11 @@ func (a *UptimeService) ListUptimeTestAlertsExecute(r APIListUptimeTestAlertsReq
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
-	if r.start != nil {
-		queryParams.Add("start", parameterToString(*r.start))
-	}
 	if r.limit != nil {
 		queryParams.Add("limit", parameterToString(*r.limit))
+	}
+	if r.before != nil {
+		queryParams.Add("before", parameterToString(*r.before))
 	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
@@ -1040,26 +1040,19 @@ type APIListUptimeTestHistoryRequest struct {
 	ctx        context.Context
 	APIService UptimeAPI
 	testId     string
-	start      *int64
-	end        *int64
 	limit      *int32
-}
-
-// Start sets start on the request type.
-func (r APIListUptimeTestHistoryRequest) Start(start int64) APIListUptimeTestHistoryRequest {
-	r.start = &start
-	return r
-}
-
-// End sets end on the request type.
-func (r APIListUptimeTestHistoryRequest) End(end int64) APIListUptimeTestHistoryRequest {
-	r.end = &end
-	return r
+	before     *int64
 }
 
 // Limit sets limit on the request type.
 func (r APIListUptimeTestHistoryRequest) Limit(limit int32) APIListUptimeTestHistoryRequest {
 	r.limit = &limit
+	return r
+}
+
+// Before sets before on the request type.
+func (r APIListUptimeTestHistoryRequest) Before(before int64) APIListUptimeTestHistoryRequest {
+	r.before = &before
 	return r
 }
 
@@ -1107,14 +1100,11 @@ func (a *UptimeService) ListUptimeTestHistoryExecute(r APIListUptimeTestHistoryR
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
-	if r.start != nil {
-		queryParams.Add("start", parameterToString(*r.start))
-	}
-	if r.end != nil {
-		queryParams.Add("end", parameterToString(*r.end))
-	}
 	if r.limit != nil {
 		queryParams.Add("limit", parameterToString(*r.limit))
+	}
+	if r.before != nil {
+		queryParams.Add("before", parameterToString(*r.before))
 	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
@@ -1182,6 +1172,20 @@ type APIListUptimeTestPeriodsRequest struct {
 	ctx        context.Context
 	APIService UptimeAPI
 	testId     string
+	limit      *int32
+	before     *int64
+}
+
+// Limit sets limit on the request type.
+func (r APIListUptimeTestPeriodsRequest) Limit(limit int32) APIListUptimeTestPeriodsRequest {
+	r.limit = &limit
+	return r
+}
+
+// Before sets before on the request type.
+func (r APIListUptimeTestPeriodsRequest) Before(before int64) APIListUptimeTestPeriodsRequest {
+	r.before = &before
+	return r
 }
 
 // Execute executes the request.
@@ -1228,6 +1232,12 @@ func (a *UptimeService) ListUptimeTestPeriodsExecute(r APIListUptimeTestPeriodsR
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
+	if r.limit != nil {
+		queryParams.Add("limit", parameterToString(*r.limit))
+	}
+	if r.before != nil {
+		queryParams.Add("before", parameterToString(*r.before))
+	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
 

--- a/api_uptime_test.go
+++ b/api_uptime_test.go
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -397,6 +397,12 @@ func TestListUptimeTests(t *testing.T) {
 						"uptime":         Decimal(100),
 					}, 1,
 				),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": Like(5),
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {
@@ -435,6 +441,12 @@ func TestListUptimeTests(t *testing.T) {
 			WithHeader("Content-Type", S("application/json")).
 			WithJSONBody(Map{
 				"data": Like([]interface{}{}),
+				"metadata": matchers.StructMatcher{
+					"page":        Like(1),
+					"per_page":    Like(25),
+					"page_count":  Like(1),
+					"total_count": 0,
+				},
 			})
 
 		executeTest(t, func(c *statuscake.Client) error {

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/backoff/constant.go
+++ b/backoff/constant.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/backoff/linear.go
+++ b/backoff/linear.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -88,7 +88,7 @@ func (c contextKey) String() string {
 	}
 }
 
-// Client manages communication with the StatusCake API API v1.0.0-beta.1
+// Client manages communication with the StatusCake API API v1.0.0-beta.2
 // In most cases there should be only one, shared, Client.
 type Client struct {
 	options options

--- a/credentials/basic.go
+++ b/credentials/basic.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/credentials/bearer.go
+++ b/credentials/bearer.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/error.go
+++ b/error.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/error_test.go
+++ b/error_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/examples/pagespeed/main.go
+++ b/examples/pagespeed/main.go
@@ -77,9 +77,7 @@ func main() {
 
 	fmt.Printf("PAGESPEED CHECKS: %+v\n", tests.Data)
 
-	results, err := client.ListPagespeedTestHistory(context.Background(), testID).
-		Days(4).
-		Execute()
+	results, err := client.ListPagespeedTestHistory(context.Background(), testID).Execute()
 	if err != nil {
 		printError(err)
 	}

--- a/model_api_response.go
+++ b/model_api_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_api_response_data.go
+++ b/model_api_response_data.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_contact_group.go
+++ b/model_contact_group.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_contact_group_response.go
+++ b/model_contact_group_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_contact_groups.go
+++ b/model_contact_groups.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -36,16 +36,18 @@ import (
 // ContactGroups struct for ContactGroups
 type ContactGroups struct {
 	// List of contact groups
-	Data []ContactGroup `json:"data"`
+	Data     []ContactGroup `json:"data"`
+	Metadata Metadata       `json:"metadata"`
 }
 
 // NewContactGroups instantiates a new ContactGroups object.
 // This constructor will assign default values to properties that have it
 // defined, and makes sure properties required by API are set, but the set of
 // arguments will change when the set of required properties is changed.
-func NewContactGroups(data []ContactGroup) *ContactGroups {
+func NewContactGroups(data []ContactGroup, metadata Metadata) *ContactGroups {
 	return &ContactGroups{
-		Data: data,
+		Data:     data,
+		Metadata: metadata,
 	}
 }
 
@@ -54,6 +56,9 @@ func (o ContactGroups) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["data"] = o.Data
+	}
+	if true {
+		toSerialize["metadata"] = o.Metadata
 	}
 	return json.Marshal(toSerialize)
 }

--- a/model_maintenance_window.go
+++ b/model_maintenance_window.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_window_repeat_interval.go
+++ b/model_maintenance_window_repeat_interval.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_window_response.go
+++ b/model_maintenance_window_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_window_state.go
+++ b/model_maintenance_window_state.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_windows_.go
+++ b/model_maintenance_windows_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -36,16 +36,18 @@ import (
 // MaintenanceWindows struct for MaintenanceWindows
 type MaintenanceWindows struct {
 	// List of maintenance windows
-	Data []MaintenanceWindow `json:"data"`
+	Data     []MaintenanceWindow `json:"data"`
+	Metadata Metadata            `json:"metadata"`
 }
 
 // NewMaintenanceWindows instantiates a new MaintenanceWindows object.
 // This constructor will assign default values to properties that have it
 // defined, and makes sure properties required by API are set, but the set of
 // arguments will change when the set of required properties is changed.
-func NewMaintenanceWindows(data []MaintenanceWindow) *MaintenanceWindows {
+func NewMaintenanceWindows(data []MaintenanceWindow, metadata Metadata) *MaintenanceWindows {
 	return &MaintenanceWindows{
-		Data: data,
+		Data:     data,
+		Metadata: metadata,
 	}
 }
 
@@ -54,6 +56,9 @@ func (o MaintenanceWindows) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["data"] = o.Data
+	}
+	if true {
+		toSerialize["metadata"] = o.Metadata
 	}
 	return json.Marshal(toSerialize)
 }

--- a/model_metadata.go
+++ b/model_metadata.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -36,36 +36,41 @@ import (
 // Metadata struct for Metadata
 type Metadata struct {
 	// The current page of results
-	Page *int32 `json:"page,omitempty"`
+	Page int32 `json:"page"`
 	// The number of results per page
-	PerPage *int32 `json:"per_page,omitempty"`
+	PerPage int32 `json:"per_page"`
 	// The total number of pages
-	PageCount *int32 `json:"page_count,omitempty"`
+	PageCount int32 `json:"page_count"`
 	// The total number of results
-	TotalCount *int32 `json:"total_count,omitempty"`
+	TotalCount int32 `json:"total_count"`
 }
 
 // NewMetadata instantiates a new Metadata object.
 // This constructor will assign default values to properties that have it
 // defined, and makes sure properties required by API are set, but the set of
 // arguments will change when the set of required properties is changed.
-func NewMetadata() *Metadata {
-	return &Metadata{}
+func NewMetadata(page int32, perPage int32, pageCount int32, totalCount int32) *Metadata {
+	return &Metadata{
+		Page:       page,
+		PerPage:    perPage,
+		PageCount:  pageCount,
+		TotalCount: totalCount,
+	}
 }
 
 // Marshal data from the in the struct to JSON.
 func (o Metadata) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if o.Page != nil {
+	if true {
 		toSerialize["page"] = o.Page
 	}
-	if o.PerPage != nil {
+	if true {
 		toSerialize["per_page"] = o.PerPage
 	}
-	if o.PageCount != nil {
+	if true {
 		toSerialize["page_count"] = o.PageCount
 	}
-	if o.TotalCount != nil {
+	if true {
 		toSerialize["total_count"] = o.TotalCount
 	}
 	return json.Marshal(toSerialize)

--- a/model_monitoring_location.go
+++ b/model_monitoring_location.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_monitoring_location_status.go
+++ b/model_monitoring_location_status.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_monitoring_locations.go
+++ b/model_monitoring_locations.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_.go
+++ b/model_pagespeed_test_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_check_rate.go
+++ b/model_pagespeed_test_check_rate.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history.go
+++ b/model_pagespeed_test_history.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history_data.go
+++ b/model_pagespeed_test_history_data.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history_data_aggregated.go
+++ b/model_pagespeed_test_history_data_aggregated.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history_data_aggregated_filesize.go
+++ b/model_pagespeed_test_history_data_aggregated_filesize.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history_data_aggregated_loadtime.go
+++ b/model_pagespeed_test_history_data_aggregated_loadtime.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history_data_aggregated_requests.go
+++ b/model_pagespeed_test_history_data_aggregated_requests.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history_result.go
+++ b/model_pagespeed_test_history_result.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_region.go
+++ b/model_pagespeed_test_region.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_response.go
+++ b/model_pagespeed_test_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_stats.go
+++ b/model_pagespeed_test_stats.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_throttling.go
+++ b/model_pagespeed_test_throttling.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_tests.go
+++ b/model_pagespeed_tests.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -36,16 +36,18 @@ import (
 // PagespeedTests struct for PagespeedTests
 type PagespeedTests struct {
 	// List of pagespeed checks
-	Data []PagespeedTest `json:"data"`
+	Data     []PagespeedTest `json:"data"`
+	Metadata Metadata        `json:"metadata"`
 }
 
 // NewPagespeedTests instantiates a new PagespeedTests object.
 // This constructor will assign default values to properties that have it
 // defined, and makes sure properties required by API are set, but the set of
 // arguments will change when the set of required properties is changed.
-func NewPagespeedTests(data []PagespeedTest) *PagespeedTests {
+func NewPagespeedTests(data []PagespeedTest, metadata Metadata) *PagespeedTests {
 	return &PagespeedTests{
-		Data: data,
+		Data:     data,
+		Metadata: metadata,
 	}
 }
 
@@ -54,6 +56,9 @@ func (o PagespeedTests) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["data"] = o.Data
+	}
+	if true {
+		toSerialize["metadata"] = o.Metadata
 	}
 	return json.Marshal(toSerialize)
 }

--- a/model_ssl_test_.go
+++ b/model_ssl_test_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_check_rate.go
+++ b/model_ssl_test_check_rate.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_flags.go
+++ b/model_ssl_test_flags.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_mixed_content.go
+++ b/model_ssl_test_mixed_content.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_response.go
+++ b/model_ssl_test_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_tests.go
+++ b/model_ssl_tests.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -36,16 +36,18 @@ import (
 // SSLTests struct for SSLTests
 type SSLTests struct {
 	// List of SSL checks
-	Data []SSLTest `json:"data"`
+	Data     []SSLTest `json:"data"`
+	Metadata Metadata  `json:"metadata"`
 }
 
 // NewSSLTests instantiates a new SSLTests object.
 // This constructor will assign default values to properties that have it
 // defined, and makes sure properties required by API are set, but the set of
 // arguments will change when the set of required properties is changed.
-func NewSSLTests(data []SSLTest) *SSLTests {
+func NewSSLTests(data []SSLTest, metadata Metadata) *SSLTests {
 	return &SSLTests{
-		Data: data,
+		Data:     data,
+		Metadata: metadata,
 	}
 }
 
@@ -54,6 +56,9 @@ func (o SSLTests) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["data"] = o.Data
+	}
+	if true {
+		toSerialize["metadata"] = o.Metadata
 	}
 	return json.Marshal(toSerialize)
 }

--- a/model_uptime_test_.go
+++ b/model_uptime_test_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_alert.go
+++ b/model_uptime_test_alert.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_alerts.go
+++ b/model_uptime_test_alerts.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_check_rate.go
+++ b/model_uptime_test_check_rate.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_history.go
+++ b/model_uptime_test_history.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_history_result.go
+++ b/model_uptime_test_history_result.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_overview.go
+++ b/model_uptime_test_overview.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_period.go
+++ b/model_uptime_test_period.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_periods.go
+++ b/model_uptime_test_periods.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_processing_state.go
+++ b/model_uptime_test_processing_state.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_response.go
+++ b/model_uptime_test_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_status.go
+++ b/model_uptime_test_status.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_type.go
+++ b/model_uptime_test_type.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_tests.go
+++ b/model_uptime_tests.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 
@@ -37,16 +37,17 @@ import (
 type UptimeTests struct {
 	// List of uptime checks
 	Data     []UptimeTestOverview `json:"data"`
-	Metadata *Metadata            `json:"metadata,omitempty"`
+	Metadata Metadata             `json:"metadata"`
 }
 
 // NewUptimeTests instantiates a new UptimeTests object.
 // This constructor will assign default values to properties that have it
 // defined, and makes sure properties required by API are set, but the set of
 // arguments will change when the set of required properties is changed.
-func NewUptimeTests(data []UptimeTestOverview) *UptimeTests {
+func NewUptimeTests(data []UptimeTestOverview, metadata Metadata) *UptimeTests {
 	return &UptimeTests{
-		Data: data,
+		Data:     data,
+		Metadata: metadata,
 	}
 }
 
@@ -56,7 +57,7 @@ func (o UptimeTests) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["data"] = o.Data
 	}
-	if o.Metadata != nil {
+	if true {
 		toSerialize["metadata"] = o.Metadata
 	}
 	return json.Marshal(toSerialize)

--- a/options.go
+++ b/options.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/pact_test.go
+++ b/pact_test.go
@@ -23,7 +23,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/throttle/group.go
+++ b/throttle/group.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/throttle/throttle_test.go
+++ b/throttle/throttle_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/throttle/transport.go
+++ b/throttle/transport.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 

--- a/utils.go
+++ b/utils.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0-beta.1
+ * API version: 1.0.0-beta.2
  * Contact: support@statuscake.com
  */
 


### PR DESCRIPTION
All list methods return a paginated series of results. This is to
prevent large amounts of data being queried from the API at once and to
enforce the fair usage policy on the API.