### PR TITLE
Replace build directives with conditional compilation directives

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       matrix:
         go:
+        - "1.18"
+        - "1.17"
         - "1.16"
-        - "1.15"
-        - "1.14"
         include:
-        - go: "1.16"
+        - go: "1.18"
           publish: true
     steps:
     - uses: actions/checkout@v2

--- a/api_contact_groups_test.go
+++ b/api_contact_groups_test.go
@@ -1,3 +1,4 @@
+//go:build consumer
 // +build consumer
 
 /*

--- a/api_locations_test.go
+++ b/api_locations_test.go
@@ -1,3 +1,4 @@
+//go:build consumer
 // +build consumer
 
 /*

--- a/api_maintenance_windows__test.go
+++ b/api_maintenance_windows__test.go
@@ -1,3 +1,4 @@
+//go:build consumer
 // +build consumer
 
 /*

--- a/api_pagespeed_test.go
+++ b/api_pagespeed_test.go
@@ -1,3 +1,4 @@
+//go:build consumer
 // +build consumer
 
 /*

--- a/api_ssl_test.go
+++ b/api_ssl_test.go
@@ -1,3 +1,4 @@
+//go:build consumer
 // +build consumer
 
 /*

--- a/api_uptime_test.go
+++ b/api_uptime_test.go
@@ -1,3 +1,4 @@
+//go:build consumer
 // +build consumer
 
 /*

--- a/pact_test.go
+++ b/pact_test.go
@@ -1,3 +1,4 @@
+//go:build consumer
 // +build consumer
 
 /*


### PR DESCRIPTION
`//go:build` is the new conditional compilation directive introduced in
Go 1.17.

It is meant to replace `// +build` directives, as the new syntax brings
a few key improvements:

 - consistency with other existing Go directives and pragmas, e.g.
   `//go:generate`,
 - support for standard boolean expression,
 - it's supported by `go fmt`, which will automatically fix incorrect
   placement of the directive in source files.

For now the two directives will coexist until we no longer maintain
compatibility with versions of Go less than 1.17.