### PR TITLE
Retry requests with non-2xx status codes

### DIFF
--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -54,125 +54,78 @@ func TestConstant(t *testing.T) {
 }
 
 func TestExponential(t *testing.T) {
-	t.Run("returns the next duration in an exponential sequence", func(t *testing.T) {
-		b := backoff.Exponential{
-			backoff.Config{
-				BaseDelay:  1.0 * time.Second,
-				Multiplier: 2.0, // Exponential factor.
-				Jitter:     0,   // To make test predictible.
-				MaxDelay:   120 * time.Second,
-			},
-		}
+	b := backoff.Exponential{
+		BaseDelay:  1.0 * time.Second,
+		Multiplier: 2.0, // Exponential factor.
+		Jitter:     0,   // To make test predictible.
+		MaxDelay:   120 * time.Second,
+	}
 
-		retries := 5
-
-		expected := time.Duration(32 * time.Second)
-		got := b.Backoff(retries)
-
-		if expected != got {
-			t.Errorf("expected: %s, got: %s", expected, got)
-		}
-	})
-
-	t.Run("returns the base delay when there are no retries remaining", func(t *testing.T) {
-		b := backoff.Exponential{
-			backoff.Config{
-				BaseDelay:  1.0 * time.Second,
-				Multiplier: 2.0, // Exponential factor.
-				Jitter:     0,   // To make test predictible.
-				MaxDelay:   120 * time.Second,
-			},
-		}
-
-		retries := 0
-
-		expected := b.BaseDelay
-		got := b.Backoff(retries)
-
-		if expected != got {
-			t.Errorf("expected: %s, got: %s", expected, got)
-		}
-	})
-
-	t.Run("returns the maximum delay when the calculated backoff exceeds the maximum", func(t *testing.T) {
-		b := backoff.Exponential{
-			backoff.Config{
-				BaseDelay:  1.0 * time.Second,
-				Multiplier: 2.0, // Exponential factor.
-				Jitter:     0,   // To make test predictible.
-				MaxDelay:   120 * time.Second,
-			},
-		}
-
-		retries := 7
-
-		expected := b.MaxDelay
-		got := b.Backoff(retries)
-
-		if expected != got {
-			t.Errorf("expected: %s, got: %s", expected, got)
-		}
-	})
+	tests := []struct {
+		name     string
+		idx      int
+		expected time.Duration
+	}{
+		{
+			name:     "returns the base delay for the initial index",
+			idx:      0,
+			expected: b.BaseDelay,
+		},
+		{
+			name:     "returns the next duration in an exponential sequence",
+			idx:      5,
+			expected: time.Duration(32 * time.Second),
+		},
+		{
+			name:     "returns the maximum delay when the calculated backoff exceeds the maximum",
+			idx:      7,
+			expected: b.MaxDelay,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := b.Backoff(tt.idx)
+			if tt.expected != got {
+				t.Errorf("expected: %s, got: %s", tt.expected, got)
+			}
+		})
+	}
 }
 
 func TestLinear(t *testing.T) {
-	t.Run("returns the next duration in a linear sequence", func(t *testing.T) {
-		b := backoff.Linear{
-			backoff.Config{
-				BaseDelay:  1.0 * time.Second,
-				Multiplier: 1.0,
-				Jitter:     0, // To make test predictible.
-				MaxDelay:   120 * time.Second,
-			},
-		}
+	b := backoff.Linear{
+		BaseDelay: 1.0 * time.Second,
+		Jitter:    0, // To make test predictible.
+		MaxDelay:  120 * time.Second,
+	}
 
-		retries := 5
-
-		expected := time.Duration(5 * time.Second)
-		got := b.Backoff(retries)
-
-		if expected != got {
-			t.Errorf("expected: %s, got: %s", expected, got)
-		}
-	})
-
-	t.Run("returns the base delay when there are no retries remaining", func(t *testing.T) {
-		b := backoff.Linear{
-			backoff.Config{
-				BaseDelay:  1.0 * time.Second,
-				Multiplier: 1.0,
-				Jitter:     0, // To make test predictible.
-				MaxDelay:   120 * time.Second,
-			},
-		}
-
-		retries := 0
-
-		expected := b.BaseDelay
-		got := b.Backoff(retries)
-
-		if expected != got {
-			t.Errorf("expected: %s, got: %s", expected, got)
-		}
-	})
-
-	t.Run("returns the maximum delay when the calculated backoff exceeds the maximum", func(t *testing.T) {
-		b := backoff.Linear{
-			backoff.Config{
-				BaseDelay:  1.0 * time.Second,
-				Multiplier: 1.0,
-				Jitter:     0, // To make test predictible.
-				MaxDelay:   120 * time.Second,
-			},
-		}
-
-		retries := 121
-
-		expected := b.MaxDelay
-		got := b.Backoff(retries)
-
-		if expected != got {
-			t.Errorf("expected: %s, got: %s", expected, got)
-		}
-	})
+	tests := []struct {
+		name     string
+		idx      int
+		expected time.Duration
+	}{
+		{
+			name:     "returns the base delay for the initial index",
+			idx:      0,
+			expected: b.BaseDelay,
+		},
+		{
+			name:     "returns the next duration in a linear sequence",
+			idx:      5,
+			expected: time.Duration(6 * time.Second),
+		},
+		{
+			name:     "returns the maximum delay when the calculated backoff exceeds the maximum",
+			idx:      120,
+			expected: b.MaxDelay,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := b.Backoff(tt.idx)
+			if tt.expected != got {
+				t.Errorf("expected: %s, got: %s", tt.expected, got)
+			}
+		})
+	}
 }

--- a/backoff/constant.go
+++ b/backoff/constant.go
@@ -38,6 +38,6 @@ type Constant struct {
 }
 
 // Backoff returns the duration to wait.
-func (b Constant) Backoff(retries int) time.Duration {
+func (b Constant) Backoff(idx int) time.Duration {
 	return b.BaseDelay
 }

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -34,19 +34,22 @@ import "time"
 // Exponential is an implementation of a backoff strategy applying an
 // exponential function.
 type Exponential struct {
-	Config
+	BaseDelay  time.Duration
+	Multiplier float64
+	Jitter     float64
+	MaxDelay   time.Duration
 }
 
 // Backoff returns the duration to wait.
-func (b Exponential) Backoff(retries int) time.Duration {
-	if retries == 0 {
+func (b Exponential) Backoff(idx int) time.Duration {
+	if idx == 0 {
 		return b.BaseDelay
 	}
 
 	backoff, max := float64(b.BaseDelay), float64(b.MaxDelay)
-	for backoff < max && retries > 0 {
+	for backoff < max && idx > 0 {
 		backoff *= b.Multiplier
-		retries--
+		idx--
 	}
 
 	if backoff > max {

--- a/backoff/jitter.go
+++ b/backoff/jitter.go
@@ -29,28 +29,7 @@
 
 package backoff
 
-import (
-	"math/rand"
-	"time"
-)
-
-// Config defines the configuration options for backoff.
-type Config struct {
-	BaseDelay  time.Duration
-	Multiplier float64
-	Jitter     float64
-	MaxDelay   time.Duration
-}
-
-// DefaultConfig is a backoff configuration with default values. This should be
-// useful for callers who want to configure backoff with non-default values
-// only for a subset of the options.
-var DefaultConfig = Config{
-	BaseDelay:  1.0 * time.Second,
-	Multiplier: 1.0,
-	Jitter:     0.2,
-	MaxDelay:   120 * time.Second,
-}
+import "math/rand"
 
 func addJitter(backoff, jitter float64) float64 {
 	backoff *= 1 + jitter*(rand.Float64()*2-1)

--- a/backoff/linear.go
+++ b/backoff/linear.go
@@ -34,17 +34,15 @@ import "time"
 // Linear is an implementation of a backoff strategy applying a linear
 // function.
 type Linear struct {
-	Config
+	BaseDelay time.Duration
+	Jitter    float64
+	MaxDelay  time.Duration
 }
 
 // Backoff returns the duration to wait.
-func (b Linear) Backoff(retries int) time.Duration {
-	if retries == 0 {
-		return b.BaseDelay
-	}
-
+func (b Linear) Backoff(idx int) time.Duration {
 	backoff, max := float64(b.BaseDelay), float64(b.MaxDelay)
-	backoff *= b.Multiplier * float64(retries)
+	backoff *= float64(idx) + 1
 
 	if backoff > max {
 		backoff = max

--- a/client.go
+++ b/client.go
@@ -188,10 +188,11 @@ func (c *Client) callAPI(request *http.Request) (*http.Response, error) {
 
 	for backoffIdx <= c.options.maxRetries {
 		res, err = c.do(request)
-		if err != nil && backoffIdx == c.options.maxRetries {
-			break
-		}
-		if err != nil {
+		if err != nil || res.StatusCode < 200 || res.StatusCode >= 300 {
+			if backoffIdx == c.options.maxRetries {
+				err = errors.New("non 2xx status code")
+				break
+			}
 			backoffFor := c.options.backoff.Backoff(backoffIdx)
 
 			timer := time.NewTimer(backoffFor)

--- a/options.go
+++ b/options.go
@@ -40,7 +40,7 @@ import (
 )
 
 var defaultOptions = options{
-	backoff:    backoff.Constant{BaseDelay: 0},
+	backoff:    backoff.Constant{BaseDelay: 1 * time.Second},
 	client:     http.DefaultClient,
 	headers:    http.Header{},
 	maxRetries: 1,
@@ -104,7 +104,7 @@ func (sc ServerConfigurations) URL(index int, variables map[string]string) (stri
 // Strategy describes a common interface to satisfy a backoff strategy when a
 // request fails.
 type Strategy interface {
-	Backoff(retries int) time.Duration
+	Backoff(idx int) time.Duration
 }
 
 // RequestCredentials describes a common interface for attaching security


### PR DESCRIPTION
Presently the HTTP client only attempts to retry requests that have failed for technical reasons (i.e. invalid SSL, cannot connect to server, etc...) but did not fail for non-2xx status codes. This commit updates this behaviour to me more specific about error conditions.

Additionally backoff strategies have been updated and the default retry delay period has been increased to 1 second in order to give a better chance of a successful request.