### PR TITLE
Update SDK input parameters

### DIFF
--- a/api_contact_groups.go
+++ b/api_contact_groups.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/api_locations.go
+++ b/api_locations.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 
@@ -174,14 +174,7 @@ func (a *LocationsService) ListPagespeedMonitoringLocationsExecute(r APIListPage
 type APIListUptimeMonitoringLocationsRequest struct {
 	ctx        context.Context
 	APIService LocationsAPI
-	location   *string
 	regionCode *string
-}
-
-// Location sets location on the request type.
-func (r APIListUptimeMonitoringLocationsRequest) Location(location string) APIListUptimeMonitoringLocationsRequest {
-	r.location = &location
-	return r
 }
 
 // RegionCode sets regionCode on the request type.
@@ -232,9 +225,6 @@ func (a *LocationsService) ListUptimeMonitoringLocationsExecute(r APIListUptimeM
 	queryParams := url.Values{}
 	formParams := url.Values{}
 
-	if r.location != nil {
-		queryParams.Add("location", parameterToString(*r.location))
-	}
 	if r.regionCode != nil {
 		queryParams.Add("region_code", parameterToString(*r.regionCode))
 	}

--- a/api_maintenance_windows_.go
+++ b/api_maintenance_windows_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/api_pagespeed.go
+++ b/api_pagespeed.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 
@@ -540,6 +540,7 @@ type APIListPagespeedTestHistoryRequest struct {
 	testId     string
 	limit      *int32
 	before     *int64
+	after      *int64
 }
 
 // Limit sets limit on the request type.
@@ -551,6 +552,12 @@ func (r APIListPagespeedTestHistoryRequest) Limit(limit int32) APIListPagespeedT
 // Before sets before on the request type.
 func (r APIListPagespeedTestHistoryRequest) Before(before int64) APIListPagespeedTestHistoryRequest {
 	r.before = &before
+	return r
+}
+
+// After sets after on the request type.
+func (r APIListPagespeedTestHistoryRequest) After(after int64) APIListPagespeedTestHistoryRequest {
+	r.after = &after
 	return r
 }
 
@@ -603,6 +610,9 @@ func (a *PagespeedService) ListPagespeedTestHistoryExecute(r APIListPagespeedTes
 	}
 	if r.before != nil {
 		queryParams.Add("before", parameterToString(*r.before))
+	}
+	if r.after != nil {
+		queryParams.Add("after", parameterToString(*r.after))
 	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}

--- a/api_ssl.go
+++ b/api_ssl.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/api_uptime.go
+++ b/api_uptime.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 
@@ -865,6 +865,7 @@ type APIListUptimeTestAlertsRequest struct {
 	testId     string
 	limit      *int32
 	before     *int64
+	after      *int64
 }
 
 // Limit sets limit on the request type.
@@ -876,6 +877,12 @@ func (r APIListUptimeTestAlertsRequest) Limit(limit int32) APIListUptimeTestAler
 // Before sets before on the request type.
 func (r APIListUptimeTestAlertsRequest) Before(before int64) APIListUptimeTestAlertsRequest {
 	r.before = &before
+	return r
+}
+
+// After sets after on the request type.
+func (r APIListUptimeTestAlertsRequest) After(after int64) APIListUptimeTestAlertsRequest {
+	r.after = &after
 	return r
 }
 
@@ -928,6 +935,9 @@ func (a *UptimeService) ListUptimeTestAlertsExecute(r APIListUptimeTestAlertsReq
 	}
 	if r.before != nil {
 		queryParams.Add("before", parameterToString(*r.before))
+	}
+	if r.after != nil {
+		queryParams.Add("after", parameterToString(*r.after))
 	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
@@ -997,6 +1007,7 @@ type APIListUptimeTestHistoryRequest struct {
 	testId     string
 	limit      *int32
 	before     *int64
+	after      *int64
 }
 
 // Limit sets limit on the request type.
@@ -1008,6 +1019,12 @@ func (r APIListUptimeTestHistoryRequest) Limit(limit int32) APIListUptimeTestHis
 // Before sets before on the request type.
 func (r APIListUptimeTestHistoryRequest) Before(before int64) APIListUptimeTestHistoryRequest {
 	r.before = &before
+	return r
+}
+
+// After sets after on the request type.
+func (r APIListUptimeTestHistoryRequest) After(after int64) APIListUptimeTestHistoryRequest {
+	r.after = &after
 	return r
 }
 
@@ -1060,6 +1077,9 @@ func (a *UptimeService) ListUptimeTestHistoryExecute(r APIListUptimeTestHistoryR
 	}
 	if r.before != nil {
 		queryParams.Add("before", parameterToString(*r.before))
+	}
+	if r.after != nil {
+		queryParams.Add("after", parameterToString(*r.after))
 	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}
@@ -1129,6 +1149,7 @@ type APIListUptimeTestPeriodsRequest struct {
 	testId     string
 	limit      *int32
 	before     *int64
+	after      *int64
 }
 
 // Limit sets limit on the request type.
@@ -1140,6 +1161,12 @@ func (r APIListUptimeTestPeriodsRequest) Limit(limit int32) APIListUptimeTestPer
 // Before sets before on the request type.
 func (r APIListUptimeTestPeriodsRequest) Before(before int64) APIListUptimeTestPeriodsRequest {
 	r.before = &before
+	return r
+}
+
+// After sets after on the request type.
+func (r APIListUptimeTestPeriodsRequest) After(after int64) APIListUptimeTestPeriodsRequest {
+	r.after = &after
 	return r
 }
 
@@ -1192,6 +1219,9 @@ func (a *UptimeService) ListUptimeTestPeriodsExecute(r APIListUptimeTestPeriodsR
 	}
 	if r.before != nil {
 		queryParams.Add("before", parameterToString(*r.before))
+	}
+	if r.after != nil {
+		queryParams.Add("after", parameterToString(*r.after))
 	}
 	// Determine the Content-Type header.
 	contentTypes := []string{}

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/backoff/constant.go
+++ b/backoff/constant.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/backoff/jitter.go
+++ b/backoff/jitter.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/backoff/linear.go
+++ b/backoff/linear.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 
@@ -88,7 +88,7 @@ func (c contextKey) String() string {
 	}
 }
 
-// Client manages communication with the StatusCake API API v1.0.0
+// Client manages communication with the StatusCake API API v1.0.1
 // In most cases there should be only one, shared, Client.
 type Client struct {
 	options options

--- a/credentials/basic.go
+++ b/credentials/basic.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/credentials/bearer.go
+++ b/credentials/bearer.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/error.go
+++ b/error.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/error_test.go
+++ b/error_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_api_response.go
+++ b/model_api_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_api_response_data.go
+++ b/model_api_response_data.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_contact_group.go
+++ b/model_contact_group.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_contact_group_response.go
+++ b/model_contact_group_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_contact_groups.go
+++ b/model_contact_groups.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_links.go
+++ b/model_links.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_window.go
+++ b/model_maintenance_window.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_window_repeat_interval.go
+++ b/model_maintenance_window_repeat_interval.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_window_response.go
+++ b/model_maintenance_window_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_window_state.go
+++ b/model_maintenance_window_state.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_maintenance_windows_.go
+++ b/model_maintenance_windows_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_monitoring_location.go
+++ b/model_monitoring_location.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_monitoring_location_status.go
+++ b/model_monitoring_location_status.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_monitoring_locations.go
+++ b/model_monitoring_locations.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_.go
+++ b/model_pagespeed_test_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_check_rate.go
+++ b/model_pagespeed_test_check_rate.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history.go
+++ b/model_pagespeed_test_history.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_history_result.go
+++ b/model_pagespeed_test_history_result.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_region.go
+++ b/model_pagespeed_test_region.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_response.go
+++ b/model_pagespeed_test_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_stats.go
+++ b/model_pagespeed_test_stats.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_test_throttling.go
+++ b/model_pagespeed_test_throttling.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagespeed_tests.go
+++ b/model_pagespeed_tests.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_pagination.go
+++ b/model_pagination.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_.go
+++ b/model_ssl_test_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_check_rate.go
+++ b/model_ssl_test_check_rate.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_flags.go
+++ b/model_ssl_test_flags.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_mixed_content.go
+++ b/model_ssl_test_mixed_content.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_test_response.go
+++ b/model_ssl_test_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_ssl_tests.go
+++ b/model_ssl_tests.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_.go
+++ b/model_uptime_test_.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_alert.go
+++ b/model_uptime_test_alert.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_alerts.go
+++ b/model_uptime_test_alerts.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_check_rate.go
+++ b/model_uptime_test_check_rate.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_history.go
+++ b/model_uptime_test_history.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_history_result.go
+++ b/model_uptime_test_history_result.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_overview.go
+++ b/model_uptime_test_overview.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_period.go
+++ b/model_uptime_test_period.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_periods.go
+++ b/model_uptime_test_periods.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_processing_state.go
+++ b/model_uptime_test_processing_state.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_response.go
+++ b/model_uptime_test_response.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_status.go
+++ b/model_uptime_test_status.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_test_type.go
+++ b/model_uptime_test_type.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/model_uptime_tests.go
+++ b/model_uptime_tests.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/options.go
+++ b/options.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/throttle/group.go
+++ b/throttle/group.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/throttle/throttle_test.go
+++ b/throttle/throttle_test.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/throttle/transport.go
+++ b/throttle/transport.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 

--- a/utils.go
+++ b/utils.go
@@ -21,7 +21,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- * API version: 1.0.0
+ * API version: 1.0.1
  * Contact: support@statuscake.com
  */
 


### PR DESCRIPTION
Bump the version of the SDK to accommodate for the following changes:

 - Remove the `location` parameter from the uptime monitoring locations endpoint
 - Add an `after` parameter to restrict the number of resources returned from time series endpoints.